### PR TITLE
Adiciona condicional para evitar upload duplicado do APK

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,6 +100,8 @@ jobs:
         run: cd android && ./gradlew assembleRelease
 
       - name: Upload do APK como artefato
+      # Condicional para evitar upload duplicado do APK para cada versão do Node.js
+        if: matrix.node-version == 20 
         uses: actions/upload-artifact@v4
         with:
           name: app-release.apk


### PR DESCRIPTION
O job de upload do APK estava sendo executado duas vezes devido as versões diferentes do Node.js gerado pela matrix strategy criando dois artefatos com o mesmo nome.

Close #27 